### PR TITLE
企画詳細ページの作成

### DIFF
--- a/model/event.ts
+++ b/model/event.ts
@@ -1,0 +1,17 @@
+import { Genre } from "~/model/genre";
+import { Place } from "~/model/place";
+
+export interface Event {
+  id: number;
+  event_name: string;
+  event_description: string;
+  event_genre: Genre;
+  place_id: Place;
+  place_name: string;
+  org_name: string;
+  org_description: string;
+  org_twitter: string;
+  org_instagram: string;
+  org_facebook: string;
+  org_homepage: string;
+}

--- a/pages/event/[event_id].vue
+++ b/pages/event/[event_id].vue
@@ -1,28 +1,14 @@
 <script lang="ts" setup>
-import events from "@/assets/data/dammy.json";
-import { Genre, genreToString } from "../../model/genre";
-import { Place, placeToString } from "../../model/place";
-
-interface Event {
-  id: number;
-  event_name: string;
-  event_description: string;
-  event_genre: Genre;
-  place_id: Place;
-  place_name: string;
-  org_name: string;
-  org_description: string;
-  org_twitter: string;
-  org_instagram: string;
-  org_facebook: string;
-  org_homepage: string;
-}
+import events from "@/assets/data/dummy.json";
+import { genreToString } from "~/model/genre";
+import { placeToString } from "~/model/place";
+import { Event } from "~/model/event";
 
 const route = useRoute();
 const path = route.fullPath;
 const event = events.find(
   (event) => event.id === Number(route.params.event_id)
-);
+) as Event;
 
 const showNoImage = function (e) {
   e.target.onerror = null;
@@ -47,10 +33,12 @@ const iconURL = `https://storage.googleapis.com/ynufes-seiryo23-deploy.appspot.c
       </p>
     </div>
     <div class="tag-wrapper">
-      <span class="tag-place">{{ placeToString(event?.place_id) + event?.place_name }}</span>
+      <span class="tag-place">
+        {{ placeToString(event?.place_id) + event?.place_name }}
+      </span>
       <span class="tag-place">{{ genreToString(event?.event_genre) }}</span>
     </div>
-    <div class="icon-image-wraooer">
+    <div class="icon-image-wrapper">
       <img :src="iconURL" @error="showNoImage" class="event-icon-image" />
     </div>
     <div class="description-wrapper">
@@ -113,6 +101,7 @@ const iconURL = `https://storage.googleapis.com/ynufes-seiryo23-deploy.appspot.c
     }
   }
 }
+
 .tag-wrapper {
   max-width: min(40em, 90%);
   margin: 0 auto;
@@ -122,10 +111,11 @@ const iconURL = `https://storage.googleapis.com/ynufes-seiryo23-deploy.appspot.c
     border: 1px solid #3b3b3b;
     border-radius: 16px;
     font-size: 0.8rem;
-    margin-right: 4px
+    margin-right: 4px;
   }
 }
-.icon-image-wraooer {
+
+.icon-image-wrapper {
   width: 90%;
   max-width: min(40em, 90%);
   margin: 40px auto 0;
@@ -136,6 +126,7 @@ const iconURL = `https://storage.googleapis.com/ynufes-seiryo23-deploy.appspot.c
     border-radius: 20px;
   }
 }
+
 .description-wrapper {
   margin: 20px auto 0;
   max-width: min(40em, 90%);

--- a/pages/event/[event_id].vue
+++ b/pages/event/[event_id].vue
@@ -19,6 +19,7 @@ interface Event {
 }
 
 const route = useRoute();
+const path = route.fullPath;
 const event = events.find(
   (event) => event.id === Number(route.params.event_id)
 );
@@ -49,15 +50,22 @@ const iconURL = `https://storage.googleapis.com/ynufes-seiryo23-deploy.appspot.c
       <p class="event-name">{{ event?.event_name }}</p>
       <p class="org-name">{{ event?.org_name }}</p>
     </SectionFrame>
+    <div class="bread-crumbs">
+      <p>
+        <NuxtLink to="/">ホーム</NuxtLink> / <NuxtLink to="/events"
+          >企画一覧</NuxtLink
+        > / <NuxtLink :to="path">{{ event?.event_name }}</NuxtLink>
+      </p>
+    </div>
     <div class="icon-image-wraooer">
-      <img :src="iconURL" @error="showNoImage" class="event-icon-image"/>
+      <img :src="iconURL" @error="showNoImage" class="event-icon-image" />
     </div>
     <div class="description-wrapper">
       <p class="event-description" v-text="event.event_description"></p>
       <SectionTitle section-title="企画団体紹介" />
       <p class="event-description" v-text="event.org_description"></p>
     </div>
-    <PrimaryButton button-text="企画一覧へ戻る" link="/events"/>
+    <PrimaryButton button-text="企画一覧へ戻る" link="/events" />
   </div>
 </template>
 
@@ -83,6 +91,21 @@ const iconURL = `https://storage.googleapis.com/ynufes-seiryo23-deploy.appspot.c
     right: -12px;
     background-color: rgb(167, 255, 255);
     border-radius: 16px;
+  }
+}
+
+.bread-crumbs {
+  max-width: min(40em, 90%);
+  margin: 0 auto;
+
+  a {
+    font-size: 0.8rem;
+    color: #7b7b7b;
+    text-decoration: none;
+
+    &:hover {
+      color: #3b3b3b
+    }
   }
 }
 .icon-image-wraooer {

--- a/pages/event/[event_id].vue
+++ b/pages/event/[event_id].vue
@@ -3,12 +3,33 @@ import events from '@/assets/json/dammy.json';
 import { Genre, genreToString } from "../../model/genre";
 import { Place, placeToString } from "../../model/place";
 
+interface Event {
+  id: number
+  event_name: string
+  event_description: string
+  event_genre: Genre
+  place_id: Place
+  place_name: string
+  org_name: string
+  org_description: string
+  org_twitter: string
+  org_instagram: string
+  org_facebook: string
+  org_homepage: string
+}
+
 const route = useRoute();
 const event = events.find((event) => event.id === Number(route.params.event_id));
 </script>
 
 <template>
-  <div>
+  <div v-if="!event">
+    <SectionFrame>
+      <p class="event-name">企画詳細ページが見つかりませんでした</p>
+    </SectionFrame>
+    <PrimaryButton button-text="企画一覧へ戻る" link="/events" class="button-event-list" />
+  </div>
+  <div v-if="event">
     <SectionFrame>
       <p class="event-name">{{ event?.event_name }}</p>
       <p class="org-name">{{ event?.org_name }}</p>
@@ -17,6 +38,9 @@ const event = events.find((event) => event.id === Number(route.params.event_id))
 </template>
 
 <style scoped lang="scss">
+.button-event-list {
+  margin-top: 20px;
+}
 .frame-section {
   width: 90%;
   text-align: center;

--- a/pages/event/[event_id].vue
+++ b/pages/event/[event_id].vue
@@ -1,9 +1,40 @@
-<script lang="ts" setup></script>
+<script lang="ts" setup>
+import events from '@/assets/json/dammy.json';
+import { Genre, genreToString } from "../../model/genre";
+import { Place, placeToString } from "../../model/place";
+
+const route = useRoute();
+const event = events.find((event) => event.id === Number(route.params.event_id));
+</script>
 
 <template>
   <div>
-    {{ $route.params.event_id }}
+    <SectionFrame>
+      <p class="event-name">{{ event?.event_name }}</p>
+      <p class="org-name">{{ event?.org_name }}</p>
+    </SectionFrame>
   </div>
 </template>
 
-<style scoped></style>
+<style scoped lang="scss">
+.frame-section {
+  width: 90%;
+  text-align: center;
+  max-width: 600px;
+  position: relative;
+
+.event-name {
+  font-size: 20px;
+}
+
+  .org-name {
+    margin: 0;
+    padding: 8px 20px;
+    position: absolute;
+    bottom: -12px;
+    right: -12px;
+    background-color: rgb(167, 255, 255);
+    border-radius: 16px;
+  }
+}
+</style>

--- a/pages/event/[event_id].vue
+++ b/pages/event/[event_id].vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import events from "@/assets/json/dammy.json";
+import events from "@/assets/data/dammy.json";
 import { Genre, genreToString } from "../../model/genre";
 import { Place, placeToString } from "../../model/place";
 

--- a/pages/event/[event_id].vue
+++ b/pages/event/[event_id].vue
@@ -52,10 +52,14 @@ const iconURL = `https://storage.googleapis.com/ynufes-seiryo23-deploy.appspot.c
     </SectionFrame>
     <div class="bread-crumbs">
       <p>
-        <NuxtLink to="/">ホーム</NuxtLink> / <NuxtLink to="/events"
-          >企画一覧</NuxtLink
-        > / <NuxtLink :to="path">{{ event?.event_name }}</NuxtLink>
+        <NuxtLink to="/">ホーム</NuxtLink> /
+        <NuxtLink to="/events">企画一覧</NuxtLink> /
+        <NuxtLink :to="path">{{ event?.event_name }}</NuxtLink>
       </p>
+    </div>
+    <div class="tag-wrapper">
+      <span class="tag-place">{{ placeToString(event?.place_id) + event?.place_name }}</span>
+      <span class="tag-place">{{ genreToString(event?.event_genre) }}</span>
     </div>
     <div class="icon-image-wraooer">
       <img :src="iconURL" @error="showNoImage" class="event-icon-image" />
@@ -84,6 +88,7 @@ const iconURL = `https://storage.googleapis.com/ynufes-seiryo23-deploy.appspot.c
   }
 
   .org-name {
+    color: #3b3b3b;
     margin: 0;
     padding: 8px 20px;
     position: absolute;
@@ -104,8 +109,20 @@ const iconURL = `https://storage.googleapis.com/ynufes-seiryo23-deploy.appspot.c
     text-decoration: none;
 
     &:hover {
-      color: #3b3b3b
+      color: #3b3b3b;
     }
+  }
+}
+.tag-wrapper {
+  max-width: min(40em, 90%);
+  margin: 0 auto;
+
+  .tag-place {
+    padding: 3px 12px;
+    border: 1px solid #3b3b3b;
+    border-radius: 16px;
+    font-size: 0.8rem;
+    margin-right: 4px
   }
 }
 .icon-image-wraooer {

--- a/pages/event/[event_id].vue
+++ b/pages/event/[event_id].vue
@@ -1,0 +1,9 @@
+<script lang="ts" setup></script>
+
+<template>
+  <div>
+    {{ $route.params.event_id }}
+  </div>
+</template>
+
+<style scoped></style>

--- a/pages/event/[event_id].vue
+++ b/pages/event/[event_id].vue
@@ -34,17 +34,6 @@ const iconURL = `https://storage.googleapis.com/ynufes-seiryo23-deploy.appspot.c
 </script>
 
 <template>
-  <div v-if="!event">
-    <SectionFrame>
-      <p class="event-name">企画詳細ページが見つかりませんでした</p>
-    </SectionFrame>
-    <PrimaryButton
-      button-text="企画一覧へ戻る"
-      link="/events"
-      class="button-event-list"
-    />
-  </div>
-
   <div v-if="event">
     <SectionFrame>
       <p class="event-name">{{ event?.event_name }}</p>
@@ -71,12 +60,23 @@ const iconURL = `https://storage.googleapis.com/ynufes-seiryo23-deploy.appspot.c
     </div>
     <PrimaryButton button-text="企画一覧へ戻る" link="/events" />
   </div>
+  <div v-else>
+    <SectionFrame>
+      <p class="event-name">企画詳細ページが見つかりませんでした</p>
+    </SectionFrame>
+    <PrimaryButton
+      button-text="企画一覧へ戻る"
+      link="/events"
+      class="button-event-list"
+    />
+  </div>
 </template>
 
 <style scoped lang="scss">
 .button-event-list {
   margin-top: 20px;
 }
+
 .frame-section {
   width: 90%;
   text-align: center;

--- a/pages/event/[event_id].vue
+++ b/pages/event/[event_id].vue
@@ -1,25 +1,35 @@
 <script lang="ts" setup>
-import events from '@/assets/json/dammy.json';
+import events from "@/assets/json/dammy.json";
 import { Genre, genreToString } from "../../model/genre";
 import { Place, placeToString } from "../../model/place";
 
 interface Event {
-  id: number
-  event_name: string
-  event_description: string
-  event_genre: Genre
-  place_id: Place
-  place_name: string
-  org_name: string
-  org_description: string
-  org_twitter: string
-  org_instagram: string
-  org_facebook: string
-  org_homepage: string
+  id: number;
+  event_name: string;
+  event_description: string;
+  event_genre: Genre;
+  place_id: Place;
+  place_name: string;
+  org_name: string;
+  org_description: string;
+  org_twitter: string;
+  org_instagram: string;
+  org_facebook: string;
+  org_homepage: string;
 }
 
 const route = useRoute();
-const event = events.find((event) => event.id === Number(route.params.event_id));
+const event = events.find(
+  (event) => event.id === Number(route.params.event_id)
+);
+
+const showNoImage = function (e) {
+  e.target.onerror = null;
+  e.target.src = "/data/icons/events/noimage.png";
+};
+const iconURL = `https://storage.googleapis.com/ynufes-seiryo23-deploy.appspot.com/icons/${event.id
+  .toString()
+  .padStart(4, "0")}-01.webp`;
 </script>
 
 <template>
@@ -27,13 +37,27 @@ const event = events.find((event) => event.id === Number(route.params.event_id))
     <SectionFrame>
       <p class="event-name">企画詳細ページが見つかりませんでした</p>
     </SectionFrame>
-    <PrimaryButton button-text="企画一覧へ戻る" link="/events" class="button-event-list" />
+    <PrimaryButton
+      button-text="企画一覧へ戻る"
+      link="/events"
+      class="button-event-list"
+    />
   </div>
+
   <div v-if="event">
     <SectionFrame>
       <p class="event-name">{{ event?.event_name }}</p>
       <p class="org-name">{{ event?.org_name }}</p>
     </SectionFrame>
+    <div class="icon-image-wraooer">
+      <img :src="iconURL" @error="showNoImage" class="event-icon-image"/>
+    </div>
+    <div class="description-wrapper">
+      <p class="event-description" v-text="event.event_description"></p>
+      <SectionTitle section-title="企画団体紹介" />
+      <p class="event-description" v-text="event.org_description"></p>
+    </div>
+    <PrimaryButton button-text="企画一覧へ戻る" link="/events"/>
   </div>
 </template>
 
@@ -44,12 +68,12 @@ const event = events.find((event) => event.id === Number(route.params.event_id))
 .frame-section {
   width: 90%;
   text-align: center;
-  max-width: 600px;
+  max-width: min(40em, 90%);
   position: relative;
 
-.event-name {
-  font-size: 20px;
-}
+  .event-name {
+    font-size: 20px;
+  }
 
   .org-name {
     margin: 0;
@@ -59,6 +83,32 @@ const event = events.find((event) => event.id === Number(route.params.event_id))
     right: -12px;
     background-color: rgb(167, 255, 255);
     border-radius: 16px;
+  }
+}
+.icon-image-wraooer {
+  width: 90%;
+  max-width: min(40em, 90%);
+  margin: 40px auto 0;
+  text-align: center;
+
+  .event-icon-image {
+    max-width: min(60%, 320px);
+    border-radius: 20px;
+  }
+}
+.description-wrapper {
+  margin: 20px auto 0;
+  max-width: min(40em, 90%);
+
+  .event-description {
+    margin: 40px auto;
+    white-space: pre-wrap;
+    line-height: 1.6rem;
+  }
+
+  .tone-wrapper {
+    width: fit-content;
+    margin: 40px auto 20px;
   }
 }
 </style>

--- a/pages/event/[event_id].vue
+++ b/pages/event/[event_id].vue
@@ -27,7 +27,7 @@ const showNoImage = function (e) {
   e.target.onerror = null;
   e.target.src = "/data/icons/events/noimage.png";
 };
-const iconURL = `https://storage.googleapis.com/ynufes-seiryo23-deploy.appspot.com/icons/${event.id
+const iconURL = `https://storage.googleapis.com/ynufes-seiryo23-deploy.appspot.com/icons/${event?.id
   .toString()
   .padStart(4, "0")}-01.webp`;
 </script>


### PR DESCRIPTION
- add: event詳細ページ
- feat: データ(ダミー)の取得成功
- feat: エラー表示の条件分岐を作成
- feat:最低限の表示部分を作成
- fix: eventsがunefinedの時に404ページに飛ばないように修正
- fix: ダミーデータのパスを修正
