### PR TITLE
Aboutページ画像パスの問題修正

### DIFF
--- a/components/TheCarousel.vue
+++ b/components/TheCarousel.vue
@@ -25,7 +25,7 @@ const props = withDefaults(defineProps<Props>(), {
     :navigation="true"
     class="the-carousel"
   >
-    <swiper-slide v-for="image in imageList" :key="image"
+    <swiper-slide v-for="image in props.imageList" :key="image"
       ><img :src="image" class="swiper-image"
     /></swiper-slide>
   </swiper>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -5,6 +5,7 @@ export default defineNuxtConfig({
     public: {
       google_analytics_id: process.env.GOOGLE_ANALYTICS_ID,
       production_mode: process.env.PRODUCTION_MODE,
+      base_url: process.env.BASE_URL,
     },
     microCMSServiceDomain: process.env.MICROCMS_SERVICE_DOMAIN,
     microCMSApiKey: process.env.MICROCMS_API_KEY,

--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -2,15 +2,15 @@
 const conf = useRuntimeConfig();
 const basePath = conf.public.base_url;
 const imageList = [
-  "/images/22-seiryo-images/about1.webp",
-  "/images/22-seiryo-images/about2.webp",
-  "/images/22-seiryo-images/about3.webp",
-  "/images/22-seiryo-images/about4.webp",
-  "/images/22-seiryo-images/about5.webp",
-  "/images/22-seiryo-images/about6.webp",
-  "/images/22-seiryo-images/about7.webp",
-  "/images/22-seiryo-images/about8.webp",
-  "/images/22-seiryo-images/about9.webp",
+  "images/22-seiryo-images/about1.webp",
+  "images/22-seiryo-images/about2.webp",
+  "images/22-seiryo-images/about3.webp",
+  "images/22-seiryo-images/about4.webp",
+  "images/22-seiryo-images/about5.webp",
+  "images/22-seiryo-images/about6.webp",
+  "images/22-seiryo-images/about7.webp",
+  "images/22-seiryo-images/about8.webp",
+  "images/22-seiryo-images/about9.webp",
 ].map((path) => basePath + path);
 useHead({
   title: "清陵祭 - 清陵祭について",

--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+const conf = useRuntimeConfig();
+const basePath = conf.public.base_url;
 const imageList = [
   "/images/22-seiryo-images/about1.webp",
   "/images/22-seiryo-images/about2.webp",
@@ -9,7 +11,7 @@ const imageList = [
   "/images/22-seiryo-images/about7.webp",
   "/images/22-seiryo-images/about8.webp",
   "/images/22-seiryo-images/about9.webp",
-];
+].map((path) => basePath + path);
 useHead({
   title: "清陵祭 - 清陵祭について",
   meta: [


### PR DESCRIPTION
aboutページの画像パスが、baseURLを含んでいない形となっていて、アクセス不能となっていたため修正。

現状の状態: https://ynu-fes.yokohama/23/seiryo/about

元々は、 seiryo23.ynu-fes.yokohama でホスティングしていたため、当時は問題は出なかった。